### PR TITLE
Aperçu PDF multi-pages : charger et mettre en cache toutes les pages

### DIFF
--- a/eduscan.py
+++ b/eduscan.py
@@ -910,25 +910,35 @@ def analyser_pdf():
         nb_images = 0
 
     # Aperçu visuel : charger toutes les pages en images (multi-pages)
+    global page_images, current_page_image, current_page_index
+
     try:
         poppler_bin = ensure_poppler()
         pages = convert_from_path(pdf_path, 150, poppler_path=poppler_bin)
+        if not pages:
+            raise RuntimeError("Aucune page dans le PDF ?")
     except Exception as e:
         messagebox.showerror("Aperçu PDF", f"Impossible de lire le PDF :\n{e}")
         return
 
-    max_width, max_height = 600, 700
+    # Préparer les images redimensionnées pour chaque page
     page_images = []
-    for page in pages:
-        w, h = page.size
+    max_width, max_height = 600, 700
+
+    for img in pages:
+        w, h = img.size
         scale = min(max_width / w, max_height / h, 1.0)
         if scale < 1.0:
-            page = page.resize((int(w * scale), int(h * scale)))
-        page_images.append(ImageTk.PhotoImage(page))
+            img = img.resize((int(w * scale), int(h * scale)))
+        tk_img = ImageTk.PhotoImage(img)
+        page_images.append(tk_img)
 
+    # Afficher la première page si disponible
     if page_images:
+        current_page_index = 1
         current_page_image = page_images[0]
         pdf_image_label.configure(image=current_page_image)
+        update_page_nav_label()
 
     # Texte intégré
     text_integrated = ""


### PR DESCRIPTION
### Motivation
- Remplacer l’aperçu d’une seule page par un chargement multi-pages pour permettre la navigation entre pages dans l’UI.
- Charger et redimensionner toutes les pages en images afin de les mettre en cache pour une navigation fluide.
- Mettre à jour l’état de navigation (`current_page_index`, `current_page_image`) pour que les helpers de navigation puissent les utiliser.
- Améliorer la gestion d’erreur en cas d’absence de pages décodables dans le PDF.

### Description
- Dans `analyser_pdf()` la section d’aperçu a été réécrite pour déclarer `global page_images, current_page_image, current_page_index` et préparer l’état de navigation.
- Utilisation de `ensure_poppler()` et `convert_from_path()` avec un contrôle explicite `if not pages: raise RuntimeError(...)` pour détecter les PDFs vides ou illisibles.
- Redimensionnement de chaque image, conversion en `ImageTk.PhotoImage` et mise en cache dans la liste `page_images` pour éviter les recreations ultérieures.
- Affichage de la première vignette mise en cache et appel de `update_page_nav_label()` pour rafraîchir l’indicateur de page; l’extraction du texte intégré reste inchangée.

### Testing
- Aucun test automatisé n’a été exécuté sur ce changement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955734fac0483229d57c6bd02a283ed)